### PR TITLE
fix(auth): session token refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,11 +116,13 @@ Content such as deployment specific texts are loaded from `config/content` folde
 
 User and role management (email and password sign up only):
 
-To add deployment administrator and moderator users you need to add them to the `allowedEmails` in `config/config.yml` (run `pnpm postinstall` after modification to propagate to application configurations). This will restrict email/password sign up to those specified emails, all other emails will raise an error in the backend when signing up.
+To add deployment administrator and moderator users you need to add them to the `moderators` in the root `config/config.yml` file (run `pnpm postinstall` after modification to propagate to application configurations). This will restrict email/password sign up to those specified emails, all other emails will raise an error in the backend when signing up.
 
-Once a user with an email (`allowedEmails`) has signed up you can use the super admin user (created on startup with credentials in `.env`) to allocate them admin role via the OurVoice Admin application. Once a user has a role `admin` they can log into the OurVoice Admin application to modify rights for their deployment only. See list roles and right below (can be modified based on need).
+Once a user with an email (in `moderators`) has signed up you can use the super admin user (created on startup with credentials in `.env`) to allocate them admin role via the OurVoice Admin application. Once a user has a role `admin` they can log into the OurVoice Admin application to modify rights for their deployment only. See list roles and right below (can be modified based on need).
 
-> NOTE: currently session is not revoked/refreshed/claims updated on frontend token when role is assigned/removed from user. This functionality needs to be implemented see more in docs - https://supertokens.com/docs/session/common-customizations/sessions/claims/access-token-payload and https://supertokens.com/docs/session/common-customizations/sessions/claims/access-token-payload#with-session-verification-online-mode
+To add email that can use the passwordless sign in/up you need to add them to `allowedEmails` in the root `config/config.yml` file (run `pnpm postinstall` after modification to propagate to application configurations). If no emails are added this feature is disabled. To restrict the domain for emails that can sign up specify the `organisation` in the root `config/config.yml` file (run `pnpm postinstall` after modification to propagate to application configurations).
+
+> NOTE: Session token is updated using refresh call to API endpoint that checks supertoken database for updates using [Token blacklisting](https://supertokens.com/docs/passwordless/common-customizations/sessions/access-token-blacklisting). This is not a most elegant solution and other options (e.g. keeping a cache of tokens that need to be refreshed) should be used in the future. See more in docs - https://supertokens.com/docs/session/common-customizations/sessions/claims/access-token-payload and https://supertokens.com/docs/session/common-customizations/sessions/claims/access-token-payload#with-session-verification-online-mode
 
 - name: `user`
 - permissions:

--- a/apps/ourvoice-api/config/config.yml
+++ b/apps/ourvoice-api/config/config.yml
@@ -24,6 +24,8 @@ roles:
       - edit:all
       - delete:all
 allowedEmails:
+  - user@ourvoice.app
+moderators:
   - deployment_admin@ourvoice.app
   - moderator1@ourvoice.app
   - moderator2@ourvoice.app

--- a/apps/ourvoice-api/src/app.controller.ts
+++ b/apps/ourvoice-api/src/app.controller.ts
@@ -33,7 +33,7 @@ export class AppController {
   }
   @Get('refreshtoken')
   @UseGuards(new AuthGuard({ checkDatabase: true }))
-  async refreshToken() {
-    return { message: 'success' };
+  async refreshToken(@Session() session: SessionContainer) {
+    return { userId: session?.getUserId() };
   }
 }

--- a/apps/ourvoice-app/src/router/index.ts
+++ b/apps/ourvoice-app/src/router/index.ts
@@ -14,7 +14,8 @@ import {
   getCurrentDeploymentDomain,
   checkForSession,
   checkDeployment,
-  redirectTo
+  redirectTo,
+  getSessionPayload
 } from '../services/session.service'
 
 // import YamlContent from '../../../../config/config.yml'
@@ -119,7 +120,6 @@ router.beforeEach(async (to, from, next) => {
   const userStore = useUserStore()
   // check for user session
   const isSession = await checkForSession()
-  await userStore.isLoggedIn
 
   if (isSession) {
     // if current deployment matches with user then init user store

--- a/apps/ourvoice-app/src/services/session.service.ts
+++ b/apps/ourvoice-app/src/services/session.service.ts
@@ -1,6 +1,7 @@
 import Session from 'supertokens-web-js/recipe/session'
 import { EmailVerificationClaim } from 'supertokens-web-js/recipe/emailverification'
 
+// TODO: add error handling
 export const checkForSession = async () => {
   if (!(await Session.doesSessionExist())) return false
   const validationErrors = await Session.validateClaims()
@@ -19,17 +20,23 @@ export const checkForSession = async () => {
 }
 
 export const getDeployment = async () => {
+  if (!(await Session.doesSessionExist())) return ''
   const payload = await Session.getAccessTokenPayloadSecurely()
   return payload.deployment || ''
 }
 
+export const getSessionPayload = async () => {
+  if (!(await Session.doesSessionExist())) return undefined
+  return await Session.getAccessTokenPayloadSecurely()
+}
 export const getUserId = async () => {
+  if (!(await Session.doesSessionExist())) return ''
   return await Session.getUserId()
 }
 
 export const checkDeployment = async (deployment: string): Promise<boolean> => {
   const payload = await Session.getAccessTokenPayloadSecurely()
-  const userDeployment = payload.deployment || ''
+  const userDeployment = payload?.deployment || ''
   return userDeployment === deployment || userDeployment === '*'
 }
 

--- a/apps/ourvoice-app/src/stores/user.ts
+++ b/apps/ourvoice-app/src/stores/user.ts
@@ -3,6 +3,7 @@ import { defineStore } from 'pinia'
 import { useDeploymentStore } from '@/stores/deployment'
 import { uniqueNamesGenerator, adjectives, colors, animals } from 'unique-names-generator'
 import Session from 'supertokens-web-js/recipe/session'
+import { getSessionPayload, getUserId } from '../services/session.service'
 
 export interface UserState {
   userId: string
@@ -47,15 +48,15 @@ export const useUserStore = defineStore('user', {
       const deploymentStore = useDeploymentStore()
       const deployment = deploymentStore.deployment
 
-      const userId = await Session.getUserId()
+      const userId = await getUserId()
       this.userId = userId
 
       const sessionHash = await authService.hashInput(userId, deployment)
       this.sessionHash = sessionHash
 
-      const payload = await Session.getAccessTokenPayloadSecurely()
-      const userRoles = payload['st-role'].v || []
-      const userDeployment = payload.deployment || ''
+      const payload = await getSessionPayload()
+      const userRoles = payload['st-role']?.v || []
+      const userDeployment = payload?.deployment || ''
       this.userRoles = userRoles
       this.userDeployment = userDeployment
 

--- a/apps/ourvoice-auth-api/config/config.yml
+++ b/apps/ourvoice-auth-api/config/config.yml
@@ -24,6 +24,8 @@ roles:
       - edit:all
       - delete:all
 allowedEmails:
+  - user@ourvoice.app
+moderators:
   - deployment_admin@ourvoice.app
   - moderator1@ourvoice.app
   - moderator2@ourvoice.app

--- a/apps/ourvoice-auth-api/src/auth/metadata.service.ts
+++ b/apps/ourvoice-auth-api/src/auth/metadata.service.ts
@@ -24,24 +24,42 @@ export async function clearEmailAllowList() {
 export async function isEmailAllowed(email: string) {
   const existingData = await UserMetadata.getUserMetadata('emailAllowList');
   const allowList: string[] = existingData.metadata.allowList || [];
-  return allowList.includes(email);
+  // NOTE: if allowlist is empty then this feature is disabled
+  return allowList.includes(email) || allowList.length === 0;
 }
-
-export async function addPhoneNumberToAllowlist(phoneNumber: string) {
+// NOTE: using phoneNumberAllowList as a storage for storing moderators list in supertokens
+// in the future this could be moved to admin/deployment database or if supertokens extends
+// functionality to allow custom storages of metadata not linked to user
+export async function addModeratorsToAllowlist(moderators: string[]) {
   const existingData = await UserMetadata.getUserMetadata(
     'phoneNumberAllowList',
   );
   let allowList: string[] = existingData.metadata.allowList || [];
-  allowList = [...allowList, phoneNumber];
+  allowList = [...allowList, ...moderators];
   await UserMetadata.updateUserMetadata('phoneNumberAllowList', {
     allowList,
   });
 }
 
-export async function isPhoneNumberAllowed(phoneNumber: string) {
+export async function addModeratorToAllowlist(moderator: string) {
+  const existingData = await UserMetadata.getUserMetadata(
+    'phoneNumberAllowList',
+  );
+  let allowList: string[] = existingData.metadata.allowList || [];
+  allowList = [...allowList, moderator];
+  await UserMetadata.updateUserMetadata('phoneNumberAllowList', {
+    allowList,
+  });
+}
+
+export async function isModeratorAllowed(moderator: string) {
   const existingData = await UserMetadata.getUserMetadata(
     'phoneNumberAllowList',
   );
   const allowList: string[] = existingData.metadata.allowList || [];
-  return allowList.includes(phoneNumber);
+  return allowList.includes(moderator);
+}
+
+export async function clearModeratorAllowList() {
+  await UserMetadata.clearUserMetadata('phoneNumberAllowList');
 }

--- a/apps/ourvoice-auth-api/src/auth/supertokens/supertokens.service.ts
+++ b/apps/ourvoice-auth-api/src/auth/supertokens/supertokens.service.ts
@@ -17,7 +17,7 @@ import UserMetadata from 'supertokens-node/recipe/usermetadata';
 import UserRoles from 'supertokens-node/recipe/userroles';
 
 import { addRoleToUser } from '../roles.service';
-import { isEmailAllowed } from '../metadata.service';
+import { isEmailAllowed, isModeratorAllowed } from '../metadata.service';
 
 @Injectable()
 export class SupertokensService {
@@ -83,7 +83,7 @@ export class SupertokensService {
               validate: async (email: string) => {
                 // TODO: this should eventually come from admin database
                 if (
-                  !(await isEmailAllowed(email)) &&
+                  !(await isModeratorAllowed(email)) &&
                   // check if this is app super admin who is login in
                   config.adminEmail !== email
                 ) {
@@ -277,6 +277,23 @@ export class SupertokensService {
           apis: (originalImplementation) => {
             return {
               ...originalImplementation,
+              createCodePOST: async function (input) {
+                if ('email' in input) {
+                  const existingUser = await Passwordless.getUserByEmail({
+                    email: input.email,
+                  });
+                  if (existingUser === undefined) {
+                    // this is sign up attempt
+                    if (!(await isEmailAllowed(input.email))) {
+                      return {
+                        status: 'GENERAL_ERROR',
+                        message: 'Sign up disabled. Please contact the admin.',
+                      };
+                    }
+                  }
+                }
+                return await originalImplementation.createCodePOST!(input);
+              },
               consumeCodePOST: async (input) => {
                 if (originalImplementation.consumeCodePOST === undefined) {
                   throw Error('Should never come here');

--- a/apps/ourvoice-auth-api/src/main.ts
+++ b/apps/ourvoice-auth-api/src/main.ts
@@ -8,6 +8,7 @@ import { SupertokensExceptionFilter } from './auth/auth.filter';
 import { createRole } from './auth/roles.service';
 import {
   addEmailsToAllowlist,
+  addModeratorsToAllowlist,
   // clearEmailAllowList,
 } from './auth/metadata.service';
 import { addSuperAdmin } from './seed';
@@ -65,13 +66,20 @@ async function bootstrap() {
   app.use(errorHandler());
   app.useGlobalFilters(new SupertokensExceptionFilter());
   // create roles
+  console.log('Creating roles...');
   configService
     .get<Role[]>('roles')
     .map(async (role) => await createRole(role.name, role.permissions));
   // if you need to clear the allowedEmails list
   // await clearEmailAllowList();
-  //add allowed moderator emails
+  // add allowed emails who can sign up
+  console.log('Updating email allow list...');
   await addEmailsToAllowlist(configService.get<string[]>('allowedEmails'));
+  // if you need to clear the allowedEmails list
+  // await clearModeratorAllowList();
+  // add moderators who can sign up using email
+  console.log('Updating moderators list...');
+  await addModeratorsToAllowlist(configService.get<string[]>('moderators'));
   // add super admin user
   await addSuperAdmin(
     configService.get<string>('SUPERTOKENS_ADMIN_EMAIL') ||

--- a/apps/ourvoice-auth/src/views/PasswordlessView.vue
+++ b/apps/ourvoice-auth/src/views/PasswordlessView.vue
@@ -228,12 +228,14 @@ export default defineComponent({
     },
 
     sendMagicLink: async function () {
-      if (this.email.substring(this.email.lastIndexOf('@') + 1) !== organisation) {
+      // check for organisation restrictions
+      if (organisation && this.email.substring(this.email.lastIndexOf('@') + 1) !== organisation) {
         this.processing = false
         this.errorMessage = 'Organisation does not match'
         this.error = true
         return
       }
+
       try {
         await Passwordless.createCode({
           email: this.email

--- a/config/config.yml
+++ b/config/config.yml
@@ -24,6 +24,8 @@ roles:
       - edit:all
       - delete:all
 allowedEmails:
+  - user@ourvoice.app
+moderators:
   - deployment_admin@ourvoice.app
   - moderator1@ourvoice.app
   - moderator2@ourvoice.app


### PR DESCRIPTION
**Fixed:**
- session token refresh to work with user Pinia store (session token updates had racing conditions)

**Added:**
- configurable `allowedEmails` to sign up using passwordless (if left empty then feature is disabled)
- `moderators` list to config that are allowed to sign up via email/password (full description in docs)
- checks for `organisation` in configuration being empty/undefined (email domain check is then disabled)
- improved documentation about adding allowed users and moderators