### PR TITLE
feat(consent): added consent flow

### DIFF
--- a/apps/ourvoice-api/src/auth/supertokens/supertokens.service.ts
+++ b/apps/ourvoice-api/src/auth/supertokens/supertokens.service.ts
@@ -33,6 +33,7 @@ export class SupertokensService {
                   input.accessTokenPayload = {
                     ...input.accessTokenPayload,
                     deployment: metadata.deployment || '',
+                    consent: metadata.consent || '',
                   };
                   return originalImplementation.createNewSession(input);
                 },

--- a/apps/ourvoice-api/src/modules/users/users.controller.ts
+++ b/apps/ourvoice-api/src/modules/users/users.controller.ts
@@ -70,13 +70,18 @@ export class UserController {
     @Session() session: SessionContainer,
   ): Promise<{ message: string }> {
     const userId = session.getUserId();
-
+    const now = new Date().toISOString();
     const { status } = await this.metadataService.update(userId, {
-      consent: new Date().toISOString(),
+      consent: now,
     });
     // TODO: error handling
-    if (status === 'OK')
+    if (status === 'OK') {
+      // update session payload
+      await session.mergeIntoAccessTokenPayload({
+        consent: now,
+      });
       return { message: 'successfully updated user consent' };
+    }
   }
   //   Probably not needed as an endpoint
   @Post('consent/check')

--- a/apps/ourvoice-app/src/App.vue
+++ b/apps/ourvoice-app/src/App.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="flex flex-col w-full">
     <Navbar />
+    <ConsentModal />
     <Suspense>
       <RouterView />
     </Suspense>
@@ -9,6 +10,7 @@
 
 <script setup lang="ts">
 import Navbar from './components/common/Navbar.vue'
+import ConsentModal from './components/common/ConsentModal.vue'
 </script>
 <style>
 @import '@/assets/main.css';

--- a/apps/ourvoice-app/src/components/common/ConsentModal.vue
+++ b/apps/ourvoice-app/src/components/common/ConsentModal.vue
@@ -1,0 +1,76 @@
+<template>
+  <!-- Consent Modal -->
+  <div
+    class="fixed inset-0 bg-gray-600 bg-opacity-50 overflow-y-auto h-full w-full"
+    id="my-modal"
+    v-show="isConsentModalVisible"
+  >
+    <!-- consent modal content-->
+    <div class="relative top-20 mx-auto p-5 border w-96 shadow-lg rounded-md bg-white">
+      <div class="mt-3 text-center">
+        <h3 class="text-lg leading-6 font-medium text-gray-900">Consent Form</h3>
+        <div class="mt-2 px-7 py-3">
+          <Consent class="text-ourvoice-grey text-lg text-center lg:text-left mb-6" ref="consent" />
+        </div>
+        <div class="items-center px-4 py-3">
+          <button
+            class="px-4 py-2 bg-blue-500 text-white text-base font-medium rounded-md w-full shadow-sm hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-300"
+            @click="acceptConsent"
+          >
+            I agree
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue'
+import { mapStores } from 'pinia'
+
+import UserService from '../../services/user-service'
+import { useUserStore } from '../../stores/user'
+
+import Consent from '../../../../../config/content/consent.md'
+
+export default defineComponent({
+  components: {
+    Consent
+  },
+  data() {
+    return {
+      isConsentModalVisible: false,
+      consentEffectiveDate: new Date()
+    }
+  },
+  computed: {
+    ...mapStores(useUserStore)
+  },
+  methods: {
+    checkForConsent: async function () {
+      if (!(await this.userStore.isLoggedIn)) return
+      this.isConsentModalVisible =
+        !this.userStore.consentDate || this.consentEffectiveDate > this.userStore.consentDate
+          ? true
+          : false
+    },
+    acceptConsent: async function () {
+      const response = await UserService.updateUserConsent()
+      if (response.status === 200) {
+        this.isConsentModalVisible = false
+      }
+    }
+  },
+  async mounted() {
+    // get consent effective date
+    this.consentEffectiveDate =
+      new Date((this.$refs['consent'] as any).frontmatter.effective_date) || null
+    this.checkForConsent()
+  }
+})
+</script>
+
+<style></style>
+
+function ref(arg0: boolean) { throw new Error("Function not implemented."); }

--- a/apps/ourvoice-app/src/services/user-service.ts
+++ b/apps/ourvoice-app/src/services/user-service.ts
@@ -1,0 +1,13 @@
+import axios from 'axios'
+
+import config from '@/config'
+
+const API_URL = config.apiURL
+const BASE_URL = API_URL + '/users'
+
+export default {
+  async updateUserConsent() {
+    const response = await axios.put(`${BASE_URL}/consent`)
+    return response
+  }
+}

--- a/apps/ourvoice-app/src/stores/user.ts
+++ b/apps/ourvoice-app/src/stores/user.ts
@@ -11,6 +11,7 @@ export interface UserState {
   nickname: string
   userRoles: string[]
   userDeployment: string
+  consentDate: Date | null
 }
 
 export const useUserStore = defineStore('user', {
@@ -19,7 +20,8 @@ export const useUserStore = defineStore('user', {
     sessionHash: '',
     nickname: '',
     userRoles: [],
-    userDeployment: ''
+    userDeployment: '',
+    consentDate: null
   }),
   getters: {
     isLoggedIn: async () => {
@@ -59,6 +61,7 @@ export const useUserStore = defineStore('user', {
       const userDeployment = payload?.deployment || ''
       this.userRoles = userRoles
       this.userDeployment = userDeployment
+      this.consentDate = new Date(payload.consent)
 
       const nickname = uniqueNamesGenerator({
         dictionaries: [adjectives, colors, animals],

--- a/apps/ourvoice-app/src/views/HomeView.vue
+++ b/apps/ourvoice-app/src/views/HomeView.vue
@@ -36,31 +36,6 @@
         alt="OurVoice interface"
       />
     </div>
-
-    <!-- Consent Modal -->
-    <div
-      class="fixed inset-0 bg-gray-600 bg-opacity-50 overflow-y-auto h-full w-full"
-      id="my-modal"
-      v-show="isConsentModalVisible"
-    >
-      <!-- consent modal content-->
-      <div class="relative top-20 mx-auto p-5 border w-96 shadow-lg rounded-md bg-white">
-        <div class="mt-3 text-center">
-          <h3 class="text-lg leading-6 font-medium text-gray-900">Consent Form</h3>
-          <div class="mt-2 px-7 py-3">
-            <Consent class="text-ourvoice-grey text-lg text-center lg:text-left mb-6" />
-          </div>
-          <div class="items-center px-4 py-3">
-            <button
-              class="px-4 py-2 bg-blue-500 text-white text-base font-medium rounded-md w-full shadow-sm hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-300"
-              @click="acceptConsent"
-            >
-              I agree
-            </button>
-          </div>
-        </div>
-      </div>
-    </div>
   </div>
 </template>
 
@@ -72,12 +47,11 @@ import { EmailVerificationClaim } from 'supertokens-web-js/recipe/emailverificat
 import YamlContent from '../../../../config/config.yml'
 import Description from '../../../../config/content/description.md'
 import Information from '../../../../config/content/information.md'
-import Consent from '../../../../config/content/consent.md'
 
-import UserService from '@/services/user-service'
-
-import { useDeploymentStore } from '@/stores/deployment'
-import config from '@/config'
+import { useDeploymentStore } from '../stores/deployment'
+import config from '../config'
+import { mapStores } from 'pinia'
+import { useUserStore } from '../stores/user'
 
 const apiURL = config.apiURL
 const authBaseURL = config.authURL + '/signinWithoutPassword'
@@ -85,8 +59,8 @@ const authBaseURL = config.authURL + '/signinWithoutPassword'
 export default defineComponent({
   components: {
     Description,
-    Information,
-    Consent
+    Information
+    // Consent
   },
   props: ['deployment'],
   data() {
@@ -96,9 +70,11 @@ export default defineComponent({
       session: false,
       userId: '',
       authURL: `${authBaseURL}?d=${this.deployment}`,
-      deploymentStore: useDeploymentStore(),
-      isConsentModalVisible: false
+      deploymentStore: useDeploymentStore()
     }
+  },
+  computed: {
+    ...mapStores(useUserStore)
   },
   methods: {
     // TODO: this list might be coming from the database later
@@ -137,24 +113,11 @@ export default defineComponent({
       const json = await response.json()
 
       window.alert('Session Information:\n' + JSON.stringify(json, null, 2))
-    },
-    checkForConsent: async function () {
-      let payload = await Session.getAccessTokenPayloadSecurely()
-      if (!payload.consent) this.isConsentModalVisible = true
-    },
-    acceptConsent: async function () {
-      const response = await UserService.updateUserConsent()
-      if (response.status === 200) {
-        this.isConsentModalVisible = false
-      }
     }
   },
 
   async mounted() {
-    // this function checks if a session exists, and if not,
-    // it will redirect to the login screen.
     await this.checkForSession()
-    await this.checkForConsent()
   }
 })
 </script>

--- a/apps/ourvoice-app/src/views/HomeView.vue
+++ b/apps/ourvoice-app/src/views/HomeView.vue
@@ -1,8 +1,5 @@
 <template>
   <div class="container flex flex-col-reverse lg:flex-row items-center gap-12 mt-14 lg:mt-28 fill">
-    <!-- <div v-if="session" class="top-bar">
-      <div class="sign-out" v-on:click="signOut">SIGN OUT</div>
-    </div> -->
     <!-- Content -->
     <div class="flex fill flex-1 flex-col items-center lg:items-start">
       <h1 class="text-ourvoice-blue text-5xl md:text-6 lg:text-6xl text-center lg:text-left mb-6">
@@ -39,6 +36,31 @@
         alt="OurVoice interface"
       />
     </div>
+
+    <!-- Consent Modal -->
+    <div
+      class="fixed inset-0 bg-gray-600 bg-opacity-50 overflow-y-auto h-full w-full"
+      id="my-modal"
+      v-show="isConsentModalVisible"
+    >
+      <!-- consent modal content-->
+      <div class="relative top-20 mx-auto p-5 border w-96 shadow-lg rounded-md bg-white">
+        <div class="mt-3 text-center">
+          <h3 class="text-lg leading-6 font-medium text-gray-900">Consent Form</h3>
+          <div class="mt-2 px-7 py-3">
+            <Consent class="text-ourvoice-grey text-lg text-center lg:text-left mb-6" />
+          </div>
+          <div class="items-center px-4 py-3">
+            <button
+              class="px-4 py-2 bg-blue-500 text-white text-base font-medium rounded-md w-full shadow-sm hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-300"
+              @click="acceptConsent"
+            >
+              I agree
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
   </div>
 </template>
 
@@ -50,6 +72,9 @@ import { EmailVerificationClaim } from 'supertokens-web-js/recipe/emailverificat
 import YamlContent from '../../../../config/config.yml'
 import Description from '../../../../config/content/description.md'
 import Information from '../../../../config/content/information.md'
+import Consent from '../../../../config/content/consent.md'
+
+import UserService from '@/services/user-service'
 
 import { useDeploymentStore } from '@/stores/deployment'
 import config from '@/config'
@@ -60,7 +85,8 @@ const authBaseURL = config.authURL + '/signinWithoutPassword'
 export default defineComponent({
   components: {
     Description,
-    Information
+    Information,
+    Consent
   },
   props: ['deployment'],
   data() {
@@ -70,7 +96,8 @@ export default defineComponent({
       session: false,
       userId: '',
       authURL: `${authBaseURL}?d=${this.deployment}`,
-      deploymentStore: useDeploymentStore()
+      deploymentStore: useDeploymentStore(),
+      isConsentModalVisible: false
     }
   },
   methods: {
@@ -78,16 +105,9 @@ export default defineComponent({
     getConfig(option: string) {
       return YamlContent[option]
     },
-    // signOut: async function () {
-    //   await Session.signOut()
-    //   window.location.assign('/')
-    // },
-
     checkForSession: async function () {
       if (!(await Session.doesSessionExist())) return
       let validationErrors = await Session.validateClaims()
-      // let payload = await Session.getAccessTokenPayloadSecurely()
-      // console.log(payload)
 
       if (validationErrors.length === 0) {
         // user has verified their email address
@@ -117,6 +137,16 @@ export default defineComponent({
       const json = await response.json()
 
       window.alert('Session Information:\n' + JSON.stringify(json, null, 2))
+    },
+    checkForConsent: async function () {
+      let payload = await Session.getAccessTokenPayloadSecurely()
+      if (!payload.consent) this.isConsentModalVisible = true
+    },
+    acceptConsent: async function () {
+      const response = await UserService.updateUserConsent()
+      if (response.status === 200) {
+        this.isConsentModalVisible = false
+      }
     }
   },
 
@@ -124,6 +154,7 @@ export default defineComponent({
     // this function checks if a session exists, and if not,
     // it will redirect to the login screen.
     await this.checkForSession()
+    await this.checkForConsent()
   }
 })
 </script>

--- a/apps/ourvoice-auth-api/src/auth/supertokens/supertokens.service.ts
+++ b/apps/ourvoice-auth-api/src/auth/supertokens/supertokens.service.ts
@@ -51,6 +51,7 @@ export class SupertokensService {
                   input.accessTokenPayload = {
                     ...input.accessTokenPayload,
                     deployment: metadata.deployment || '',
+                    consent: metadata.consent || '',
                   };
 
                   return originalImplementation.createNewSession(input);

--- a/config/config.yml
+++ b/config/config.yml
@@ -1,5 +1,5 @@
 deployment: demo
-organisation: 
+organisation: ourvoice.app
 roles:
   - name: user
     permissions:

--- a/config/config.yml
+++ b/config/config.yml
@@ -1,5 +1,5 @@
 deployment: demo
-organisation: ourvoice.app
+organisation: 
 roles:
   - name: user
     permissions:

--- a/config/content/consent.md
+++ b/config/content/consent.md
@@ -3,4 +3,4 @@ name: Consent Form
 deployment: OURVOICE.APP
 ---
 
-# Consent Form
+This is the information text for {{frontmatter.deployment}} from _consent.md_ file

--- a/config/content/consent.md
+++ b/config/content/consent.md
@@ -1,6 +1,7 @@
 ---
 name: Consent Form
 deployment: OURVOICE.APP
+effective_date: 2023-07-19
 ---
 
 This is the information text for {{frontmatter.deployment}} from _consent.md_ file


### PR DESCRIPTION
Added:

- consent data into `sessionpayload`
- consent check on initial login
- consent modal popup with markdown template

Future:

~Maybe it makes more sense to add consent checking into the router for all endpoint. Also then it checks if consent has changed while active sessions are running.~