### PR TITLE
chore(app): remove the need to have api running to generate types

### DIFF
--- a/apps/ourvoice-app/codegen.ts
+++ b/apps/ourvoice-app/codegen.ts
@@ -2,7 +2,13 @@ import type { CodegenConfig } from '@graphql-codegen/cli'
 import * as path from 'path'
 
 const config: CodegenConfig = {
-  schema: 'http://localhost:3000/graphql',
+  // for some reason codegen needs the datetime.graphql to be specified first
+  // or else it cannot resolve the DateTime scalar type
+  schema: [
+    "../ourvoice-api/src/graphql/schemas/datetime.graphql",
+    "../ourvoice-api/src/modules/**/*.graphql",
+    "../ourvoice-api/src/graphql/schemas/user.graphql",
+  ],
   documents: path.join("./src/graphql/**/**.ts"),
   ignoreNoDocuments: false,
   generates: {

--- a/apps/ourvoice-app/src/graphql/generated/graphql.ts
+++ b/apps/ourvoice-app/src/graphql/generated/graphql.ts
@@ -327,7 +327,6 @@ export type ModerationPostsFilterInput = {
 };
 
 export type Mutation = {
-  _empty: Maybe<Scalars['String']['output']>;
   approveModerationCommentVersion: Maybe<ModerationComment>;
   approveModerationPostVersion: Maybe<ModerationPost>;
   createCategory: Category;
@@ -603,7 +602,6 @@ export type PresignedUrl = {
 };
 
 export type Query = {
-  _empty: Maybe<Scalars['String']['output']>;
   categories: Maybe<CategoryConnection>;
   category: Maybe<Category>;
   comment: Maybe<Comment>;


### PR DESCRIPTION
The type definitions are now obtained from the api's `.graphql` files instead of a running server.