### PR TITLE
Feat/mod approve reject queue

### DIFF
--- a/apps/ourvoice-api/prisma-main/test/migrations/20230720070502_add_unique_constraint_for_vote/migration.sql
+++ b/apps/ourvoice-api/prisma-main/test/migrations/20230720070502_add_unique_constraint_for_vote/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[authorHash,postId,commentId]` on the table `Vote` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateIndex
+CREATE UNIQUE INDEX "Vote_authorHash_postId_commentId_key" ON "Vote"("authorHash", "postId", "commentId");

--- a/apps/ourvoice-api/prisma-main/test/schema.prisma
+++ b/apps/ourvoice-api/prisma-main/test/schema.prisma
@@ -86,4 +86,6 @@ model Vote {
   postId         Int
   comment        Comment? @relation(fields: [commentId], references: [id], onDelete: Cascade, onUpdate: Cascade)
   commentId      Int?
+
+  @@unique([authorHash, postId, commentId])
 }

--- a/apps/ourvoice-api/prisma-moderation/migrations/20230720062020_post_comment_add_published_field_and_timestamps/migration.sql
+++ b/apps/ourvoice-api/prisma-moderation/migrations/20230720062020_post_comment_add_published_field_and_timestamps/migration.sql
@@ -1,0 +1,9 @@
+-- AlterTable
+ALTER TABLE "Comment" ADD COLUMN     "archivedAt" TIMESTAMP(3),
+ADD COLUMN     "published" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "publishedAt" TIMESTAMP(3);
+
+-- AlterTable
+ALTER TABLE "Post" ADD COLUMN     "archivedAt" TIMESTAMP(3),
+ADD COLUMN     "published" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "publishedAt" TIMESTAMP(3);

--- a/apps/ourvoice-api/prisma-moderation/schema.prisma
+++ b/apps/ourvoice-api/prisma-moderation/schema.prisma
@@ -18,7 +18,10 @@ model Post {
   status              PostStatus    @default(PENDING)
   versions            PostVersion[]
   requiredModerations Int           @default(1)
-  archived       Boolean   @default(false)
+  archived            Boolean       @default(false)
+  archivedAt          DateTime?
+  published           Boolean       @default(false)
+  publishedAt         DateTime?
 
   // Relations
   comments       Comment[]
@@ -53,7 +56,10 @@ model Comment {
   status              PostStatus       @default(PENDING)
   versions            CommentVersion[]
   requiredModerations Int              @default(1)
-  archived          Boolean   @default(false)
+  archived            Boolean          @default(false)
+  archivedAt          DateTime?
+  published           Boolean          @default(false)
+  publishedAt         DateTime?
 
   // Relations
   authorHash        String

--- a/apps/ourvoice-api/prisma-moderation/test/migrations/20230720070036_add_published_field_and_timestamps/migration.sql
+++ b/apps/ourvoice-api/prisma-moderation/test/migrations/20230720070036_add_published_field_and_timestamps/migration.sql
@@ -1,0 +1,9 @@
+-- AlterTable
+ALTER TABLE "Comment" ADD COLUMN     "archivedAt" TIMESTAMP(3),
+ADD COLUMN     "published" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "publishedAt" TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP;
+
+-- AlterTable
+ALTER TABLE "Post" ADD COLUMN     "archivedAt" TIMESTAMP(3),
+ADD COLUMN     "published" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "publishedAt" TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP;

--- a/apps/ourvoice-api/prisma-moderation/test/schema.prisma
+++ b/apps/ourvoice-api/prisma-moderation/test/schema.prisma
@@ -18,7 +18,10 @@ model Post {
   status              PostStatus    @default(PENDING)
   versions            PostVersion[]
   requiredModerations Int           @default(1)
-  archived           Boolean       @default(false)
+  archived            Boolean       @default(false)
+  archivedAt          DateTime?
+  published           Boolean       @default(false)
+  publishedAt         DateTime?     @default(now())
 
   // Relations
   comments       Comment[]
@@ -53,7 +56,10 @@ model Comment {
   status              PostStatus       @default(PENDING)
   versions            CommentVersion[]
   requiredModerations Int              @default(1)
-  archived           Boolean          @default(false)
+  archived            Boolean          @default(false)
+  archivedAt          DateTime?
+  published           Boolean          @default(false)
+  publishedAt         DateTime?        @default(now())
 
   // Relations
   authorHash        String

--- a/apps/ourvoice-api/src/config/deployment.ts
+++ b/apps/ourvoice-api/src/config/deployment.ts
@@ -6,7 +6,7 @@ const YAML_CONFIG_FILENAME = 'config.yml';
 
 export default () => {
   if (process.env.NODE_ENV === 'test') {
-    return {};
+    return { moderatorCount: 1 };
   }
   return yaml.load(
     readFileSync(join('../../config/', YAML_CONFIG_FILENAME), 'utf8'),

--- a/apps/ourvoice-api/src/graphql.ts
+++ b/apps/ourvoice-api/src/graphql.ts
@@ -145,6 +145,8 @@ export class ModerationCommentCreateInput {
 
 export class ModerationCommentsFilterInput {
     status?: Nullable<ModerationCommentStatus>;
+    published?: Nullable<boolean>;
+    archived?: Nullable<boolean>;
 }
 
 export class ModerationCommentPaginationInput {
@@ -168,6 +170,8 @@ export class ModerationPostCreateInput {
 
 export class ModerationPostsFilterInput {
     status?: Nullable<ModerationPostStatus>;
+    published?: Nullable<boolean>;
+    archived?: Nullable<boolean>;
 }
 
 export class ModerationPostPaginationInput {

--- a/apps/ourvoice-api/src/modules/moderation/comment-moderation/comment-moderation.builder.ts
+++ b/apps/ourvoice-api/src/modules/moderation/comment-moderation/comment-moderation.builder.ts
@@ -91,6 +91,21 @@ class CommentBuilder {
     return this;
   }
 
+  withArchivedAt(archivedAt: Date | null): CommentBuilder {
+    this.comment.archivedAt = archivedAt;
+    return this;
+  }
+
+  withPublished(published: boolean): CommentBuilder {
+    this.comment.published = published;
+    return this;
+  }
+
+  withPublishedAt(publishedAt: Date | null): CommentBuilder {
+    this.comment.publishedAt = publishedAt;
+    return this;
+  }
+
   build(): Partial<Comment> {
     return this.comment;
   }

--- a/apps/ourvoice-api/src/modules/moderation/comment-moderation/comment-moderation.graphql
+++ b/apps/ourvoice-api/src/modules/moderation/comment-moderation/comment-moderation.graphql
@@ -95,6 +95,8 @@ input ModerationCommentCreateInput {
 
 input ModerationCommentsFilterInput {
   status: ModerationCommentStatus
+  published: Boolean
+  archived: Boolean
 }
 
 input ModerationCommentPaginationInput {

--- a/apps/ourvoice-api/src/modules/moderation/comment-moderation/comment-moderation.repository.integration.spec.ts
+++ b/apps/ourvoice-api/src/modules/moderation/comment-moderation/comment-moderation.repository.integration.spec.ts
@@ -1,3 +1,4 @@
+import { CommentCreateDto } from './../../comment/dto/comment-create.dto';
 import {
   PostModeration,
   CommentModeration,
@@ -132,6 +133,7 @@ describe('CommentRepository', () => {
     .withPostIdInMainDb(1)
     .withVersions([pVersion3])
     .withArchived(false)
+    .withPublished(false)
     .build();
 
   const moderation1 = new CommentModerationBuilder()
@@ -219,6 +221,7 @@ describe('CommentRepository', () => {
       .withParent(null)
       .withParentId(null)
       .withArchived(false)
+      .withPublished(false)
       .build();
 
     // Act
@@ -227,6 +230,10 @@ describe('CommentRepository', () => {
     );
 
     // Assert
+    delete comment.publishedAt;
+    delete comment.archivedAt;
+    delete comment.post.publishedAt;
+    delete comment.post.archivedAt;
     expect(comment).toEqual(firstComment);
   });
 
@@ -394,12 +401,11 @@ describe('CommentRepository', () => {
 
   it('should create a new comment for a published post', async () => {
     // Arrange
-    const commentData = {
+    const commentData: CommentCreateDto = {
       content: 'Test Content',
       authorNickname: 'Test Hash',
       authorHash: 'Test Nickname',
       postId: 1,
-      requiredModerations: getDeploymentConfig().moderatorCount,
     };
 
     // Act
@@ -409,7 +415,7 @@ describe('CommentRepository', () => {
     // Assert
     expect(createdComment.status).toEqual(PostStatus.PENDING);
     expect(createdComment.requiredModerations).toEqual(
-      commentData.requiredModerations,
+      getDeploymentConfig().moderatorCount,
     );
     expect(createdComment.versions.length).toEqual(1);
     expect(createdComment.versions[0].content).toEqual(commentData.content);
@@ -439,13 +445,12 @@ describe('CommentRepository', () => {
 
   it('should create a new child comment for a published comment of a published post', async () => {
     // Arrange
-    const commentData = {
+    const commentData: CommentCreateDto = {
       content: 'Test Content',
       authorNickname: 'Test Hash',
       authorHash: 'Test Nickname',
       postId: 1,
       parentId: 1,
-      requiredModerations: getDeploymentConfig().moderatorCount,
     };
 
     // Act
@@ -455,7 +460,7 @@ describe('CommentRepository', () => {
     // Assert
     expect(createdComment.status).toEqual(PostStatus.PENDING);
     expect(createdComment.requiredModerations).toEqual(
-      commentData.requiredModerations,
+      getDeploymentConfig().moderatorCount,
     );
     expect(createdComment.versions.length).toEqual(1);
     expect(createdComment.versions[0].content).toEqual(commentData.content);

--- a/apps/ourvoice-api/src/modules/moderation/comment-moderation/comment-moderation.repository.ts
+++ b/apps/ourvoice-api/src/modules/moderation/comment-moderation/comment-moderation.repository.ts
@@ -96,10 +96,12 @@ export class CommentModerationRepository {
   ): Promise<
     GetManyRepositoryResponse<'moderationComments', CommentIncludesVersion>
   > {
-    const { status } = filter ?? {};
+    const { status, published, archived } = filter ?? {};
 
     const where: Prisma.CommentWhereInput = {
       status: status ?? undefined,
+      published: published ?? undefined,
+      archived: archived ?? undefined,
     };
 
     const totalCount = await this.prisma.comment.count({ where });
@@ -510,7 +512,11 @@ export class CommentModerationRepository {
 
       await tx.comment.update({
         where: { id: comment.id },
-        data: { commentIdInMainDb: newCommentInMainDb.id },
+        data: {
+          commentIdInMainDb: newCommentInMainDb.id,
+          published: true,
+          publishedAt: new Date(),
+        },
       });
 
       this.logger.log(
@@ -547,7 +553,7 @@ export class CommentModerationRepository {
 
       await tx.comment.update({
         where: { id: commentId },
-        data: { archived: true },
+        data: { archived: true, archivedAt: new Date() },
       });
 
       this.logger.debug(`Archived comment with id ${comment.id}`);

--- a/apps/ourvoice-api/src/modules/moderation/comment-moderation/comment-moderation.repository.ts
+++ b/apps/ourvoice-api/src/modules/moderation/comment-moderation/comment-moderation.repository.ts
@@ -1,6 +1,7 @@
 import {
   CommentIncludesVersion,
   CommentIncludesVersionIncludesModerations,
+  CommentIncludesVersionIncludesModerationsIncludesPost,
   ModerationIncludesVersionIncludesComment,
 } from './../../../types/moderation/comment-moderation';
 import { GetManyRepositoryResponse } from './../../../types/general';
@@ -59,7 +60,7 @@ export class CommentModerationRepository {
 
   async getModerationCommentById(
     id: number,
-  ): Promise<CommentIncludesVersionIncludesModerations> {
+  ): Promise<CommentIncludesVersionIncludesModerationsIncludesPost> {
     return await this.prisma.comment.findUnique({
       where: { id },
       include: {

--- a/apps/ourvoice-api/src/modules/moderation/comment-moderation/comment-moderation.service.spec.ts
+++ b/apps/ourvoice-api/src/modules/moderation/comment-moderation/comment-moderation.service.spec.ts
@@ -1,4 +1,7 @@
-import { CommentIncludesVersion } from './../../../types/moderation/comment-moderation';
+import {
+  CommentIncludesVersion,
+  CommentIncludesVersionIncludesModerationsIncludesPost,
+} from './../../../types/moderation/comment-moderation';
 import { CommentModifyDto } from './dto/comment-modify.dto';
 import { ModerationCommentStatus } from '../../../graphql';
 import {
@@ -145,9 +148,7 @@ describe('CommentModerationService', () => {
     // Arrange
     const commentId = 1;
     commentModerationRepositoryMock.getModerationCommentById.mockResolvedValue(
-      dummyComment as Comment & {
-        versions: (CommentVersion & { moderations: CommentModeration[] })[];
-      },
+      dummyComment as CommentIncludesVersionIncludesModerationsIncludesPost,
     );
 
     // Act
@@ -406,9 +407,7 @@ describe('CommentModerationService', () => {
     const reason = 'Test Reason';
 
     commentModerationRepositoryMock.getModerationCommentById.mockResolvedValue(
-      dummyComment as Comment & {
-        versions: (CommentVersion & { moderations: CommentModeration[] })[];
-      },
+      dummyComment as CommentIncludesVersionIncludesModerationsIncludesPost,
     );
 
     commentModerationRepositoryMock.approveCommentVersion.mockResolvedValue(
@@ -486,9 +485,7 @@ describe('CommentModerationService', () => {
     const reason = 'Test Reason';
 
     commentModerationRepositoryMock.getModerationCommentById.mockResolvedValue(
-      dummyComment as Comment & {
-        versions: (CommentVersion & { moderations: CommentModeration[] })[];
-      },
+      dummyComment as CommentIncludesVersionIncludesModerationsIncludesPost,
     );
 
     commentModerationRepositoryMock.rejectCommentVersion.mockResolvedValue(

--- a/apps/ourvoice-api/src/modules/moderation/comment-moderation/dto/comments-filter.dto.ts
+++ b/apps/ourvoice-api/src/modules/moderation/comment-moderation/dto/comments-filter.dto.ts
@@ -1,8 +1,16 @@
-import { IsOptional, IsString } from 'class-validator';
+import { IsOptional, IsString, IsBoolean } from 'class-validator';
 import { ModerationCommentStatus } from '../../../../graphql';
 
 export class ModerationCommentsFilterDto {
   @IsOptional()
   @IsString()
   status?: ModerationCommentStatus;
+
+  @IsOptional()
+  @IsBoolean()
+  archived?: boolean;
+
+  @IsOptional()
+  @IsBoolean()
+  published?: boolean;
 }

--- a/apps/ourvoice-api/src/modules/moderation/post-moderation/dto/posts-filter.dto.ts
+++ b/apps/ourvoice-api/src/modules/moderation/post-moderation/dto/posts-filter.dto.ts
@@ -1,8 +1,16 @@
-import { IsOptional, IsString } from 'class-validator';
+import { IsBoolean, IsOptional, IsString } from 'class-validator';
 import { ModerationPostStatus } from '../../../../graphql';
 
 export class ModerationPostsFilterDto {
   @IsOptional()
   @IsString()
   status?: ModerationPostStatus;
+
+  @IsOptional()
+  @IsBoolean()
+  archived?: boolean;
+
+  @IsOptional()
+  @IsBoolean()
+  published?: boolean;
 }

--- a/apps/ourvoice-api/src/modules/moderation/post-moderation/post-moderation.builder.ts
+++ b/apps/ourvoice-api/src/modules/moderation/post-moderation/post-moderation.builder.ts
@@ -54,6 +54,21 @@ class PostBuilder {
     return this;
   }
 
+  withPublished(published: boolean): PostBuilder {
+    this.post.published = published;
+    return this;
+  }
+
+  withArchivedAt(archivedAt: Date): PostBuilder {
+    this.post.archivedAt = archivedAt;
+    return this;
+  }
+
+  withPublishedAt(publishedAt: Date): PostBuilder {
+    this.post.publishedAt = publishedAt;
+    return this;
+  }
+
   build(): Partial<Post> {
     return this.post;
   }

--- a/apps/ourvoice-api/src/modules/moderation/post-moderation/post-moderation.graphql
+++ b/apps/ourvoice-api/src/modules/moderation/post-moderation/post-moderation.graphql
@@ -93,6 +93,8 @@ input ModerationPostCreateInput {
 
 input ModerationPostsFilterInput {
   status: ModerationPostStatus
+  published: Boolean
+  archived: Boolean
 }
 
 input ModerationPostPaginationInput {

--- a/apps/ourvoice-api/src/modules/moderation/post-moderation/post-moderation.repository.integration.spec.ts
+++ b/apps/ourvoice-api/src/modules/moderation/post-moderation/post-moderation.repository.integration.spec.ts
@@ -1,3 +1,4 @@
+import { PostCreateDto } from './../../post/dto/post-create.dto';
 import {
   PostModeration,
   PostStatus,
@@ -188,7 +189,16 @@ describe('PostRepository', () => {
     const post = await postModerationRepository.getModerationPostById(1);
 
     // Assert
-    expect(post).toEqual(firstPost);
+    const expectedPost = new PostBuilder(firstPost)
+      .withArchivedAt(null)
+      .withPublished(false)
+      .withPublishedAt(new Date())
+      .build();
+
+    delete post.publishedAt;
+    delete expectedPost.publishedAt;
+
+    expect(post).toEqual(expectedPost);
   });
 
   it('should return null for non existent post id', async () => {
@@ -330,13 +340,12 @@ describe('PostRepository', () => {
 
   it('should create a new post', async () => {
     // Arrange
-    const postData = {
+    const postData: PostCreateDto = {
       title: 'Test Title',
       content: 'Test Content',
       authorNickname: 'Test Hash',
       authorHash: 'Test Nickname',
       categoryIds: [1, 2],
-      requiredModerations: getDeploymentConfig().moderatorCount,
     };
 
     // Act
@@ -347,7 +356,7 @@ describe('PostRepository', () => {
     // Assert
     expect(createdPost.status).toEqual(PostStatus.PENDING);
     expect(createdPost.requiredModerations).toEqual(
-      postData.requiredModerations,
+      getDeploymentConfig().moderatorCount,
     );
     expect(createdPost.versions.length).toEqual(1);
     expect(createdPost.versions[0].title).toEqual(postData.title);

--- a/apps/ourvoice-api/src/modules/moderation/post-moderation/post-moderation.repository.ts
+++ b/apps/ourvoice-api/src/modules/moderation/post-moderation/post-moderation.repository.ts
@@ -78,10 +78,12 @@ export class PostModerationRepository {
   ): Promise<
     GetManyRepositoryResponse<'moderationPosts', PostIncludesVersion>
   > {
-    const { status } = filter ?? {};
+    const { status, published, archived } = filter ?? {};
 
     const where: Prisma.PostWhereInput = {
       status: status ?? undefined,
+      published: published ?? undefined,
+      archived: archived ?? undefined,
     };
 
     const totalCount = await this.prisma.post.count({ where });
@@ -419,7 +421,11 @@ export class PostModerationRepository {
 
       await tx.post.update({
         where: { id: post.id },
-        data: { postIdInMainDb: newPostInMainDb.id },
+        data: {
+          postIdInMainDb: newPostInMainDb.id,
+          published: true,
+          publishedAt: new Date(),
+        },
       });
 
       this.logger.debug(
@@ -456,7 +462,7 @@ export class PostModerationRepository {
 
       await tx.post.update({
         where: { id: postId },
-        data: { archived: true },
+        data: { archived: true, archivedAt: new Date() },
       });
 
       this.logger.debug(`Archived post with id ${post.id}`);

--- a/apps/ourvoice-api/src/types/moderation/comment-moderation.ts
+++ b/apps/ourvoice-api/src/types/moderation/comment-moderation.ts
@@ -1,4 +1,5 @@
 import {
+  Post,
   Comment,
   CommentVersion,
   CommentModeration,
@@ -7,20 +8,34 @@ import { GetManyResponse } from '../general';
 
 export type ModerationCommentsResponse = GetManyResponse<Comment>;
 
-export type CommentVersionIncludesModerations = CommentVersion & {
-  moderations: CommentModeration[];
-};
+export type WithIncluded<T, K extends string, V> = T & Record<K, V>;
 
-export type CommentIncludesVersionIncludesModerations = Comment & {
-  versions: CommentVersionIncludesModerations[];
-};
+export type CommentVersionIncludesModerations = WithIncluded<
+  CommentVersion,
+  'moderations',
+  CommentModeration[]
+>;
 
-export type CommentIncludesVersion = Comment & { versions: CommentVersion[] };
+export type CommentIncludesVersion<T = CommentVersion> = WithIncluded<
+  Comment,
+  'versions',
+  T[]
+>;
 
-export type ModerationIncludesVersion = CommentModeration & {
-  commentVersion: CommentVersion;
-};
+export type CommentIncludesVersionIncludesModerations =
+  CommentIncludesVersion<CommentVersionIncludesModerations>;
 
-export type ModerationIncludesVersionIncludesComment = CommentModeration & {
-  commentVersion: CommentVersion & { comment: Comment };
-};
+export type CommentIncludesVersionIncludesModerationsIncludesPost =
+  WithIncluded<CommentIncludesVersionIncludesModerations, 'post', Post>;
+
+export type ModerationIncludesVersion = WithIncluded<
+  CommentModeration,
+  'commentVersion',
+  CommentVersion
+>;
+
+export type ModerationIncludesVersionIncludesComment = WithIncluded<
+  ModerationIncludesVersion,
+  'commentVersion',
+  CommentVersion & { comment: Comment }
+>;

--- a/apps/ourvoice-api/src/types/moderation/post-moderation.ts
+++ b/apps/ourvoice-api/src/types/moderation/post-moderation.ts
@@ -7,16 +7,25 @@ import { GetManyResponse } from '../general';
 
 export type ModerationPostsResponse = GetManyResponse<Post>;
 
-export type PostVersionIncludesModerations = PostVersion & {
-  moderations: PostModeration[];
-};
+export type WithIncluded<T, K extends string, V> = T & Record<K, V>;
 
-export type PostIncludesVersionIncludesModerations = Post & {
-  versions: PostVersionIncludesModerations[];
-};
+export type PostVersionIncludesModerations = WithIncluded<
+  PostVersion,
+  'moderations',
+  PostModeration[]
+>;
 
-export type PostIncludesVersion = Post & { versions: PostVersion[] };
+export type PostIncludesVersion<T = PostVersion> = WithIncluded<
+  Post,
+  'versions',
+  T[]
+>;
 
-export type ModerationIncludesVersion = PostModeration & {
-  postVersion: PostVersion;
-};
+export type PostIncludesVersionIncludesModerations =
+  PostIncludesVersion<PostVersionIncludesModerations>;
+
+export type ModerationIncludesVersion = WithIncluded<
+  PostModeration,
+  'postVersion',
+  PostVersion
+>;

--- a/apps/ourvoice-app/src/components/comment/moderation/CommentModerationList.vue
+++ b/apps/ourvoice-app/src/components/comment/moderation/CommentModerationList.vue
@@ -1,11 +1,10 @@
 <template>
   <div class="moderation-page py-5">
-    <div v-for="comment in props.comments" :key="comment.id" class="py-3">
-      <div v-if="props.comments.length === 0">
-        <p class="text-lg text-gray-600">No comments to display...</p>
-      </div>
-
-      <div v-else>
+    <div v-if="props.comments.length <= 0">
+      <EmptyState>No comments to display...</EmptyState>
+    </div>
+    <div v-else>
+      <div v-for="comment in props.comments" :key="comment.id" class="py-3">
         <ModerationCommentCard :comment="comment" :version="comment.versions[0]" />
       </div>
     </div>
@@ -14,8 +13,9 @@
 
 <script setup lang="ts">
 import { type PropType } from 'vue'
-import ModerationCommentCard from './ModerationCommentCard.vue'
 import type { ModerationComment } from '@/stores/moderation-comments'
+import ModerationCommentCard from './ModerationCommentCard.vue'
+import EmptyState from '../EmptyState.vue'
 
 const props = defineProps({
   comments: { type: Array as PropType<ModerationComment[]>, required: true }

--- a/apps/ourvoice-app/src/graphql/queries/getModerationComments.ts
+++ b/apps/ourvoice-app/src/graphql/queries/getModerationComments.ts
@@ -6,10 +6,12 @@ export const GET_MODERATION_COMMENTS_QUERY = gql`
     $after: String
     $limit: Int = 10
     $status: ModerationCommentStatus
+    $published: Boolean
+    $archived: Boolean
   ) {
     moderationComments(
       pagination: { before: $before, after: $after, limit: $limit }
-      filter: { status: $status }
+      filter: { status: $status, published: $published, archived: $archived }
     ) {
       edges {
         cursor

--- a/apps/ourvoice-app/src/graphql/queries/getModerationPosts.ts
+++ b/apps/ourvoice-app/src/graphql/queries/getModerationPosts.ts
@@ -6,10 +6,12 @@ export const GET_MODERATION_POSTS_QUERY = gql`
     $after: String
     $limit: Int = 10
     $status: ModerationPostStatus
+    $archived: Boolean
+    $published: Boolean
   ) {
     moderationPosts(
       pagination: { before: $before, after: $after, limit: $limit }
-      filter: { status: $status }
+      filter: { status: $status, archived: $archived, published: $published }
     ) {
       edges {
         cursor

--- a/apps/ourvoice-app/src/stores/moderation-comments.ts
+++ b/apps/ourvoice-app/src/stores/moderation-comments.ts
@@ -87,6 +87,8 @@ export const useModerationCommentsStore = defineStore('moderation-comments', {
           query: GET_MODERATION_COMMENTS_QUERY,
           variables: {
             status: status,
+            published: status === 'APPROVED' ? false : undefined,
+            archived: status === 'REJECTED' ? false : undefined,
             limit: MODERATION_LIST_COMMENTS_PER_PAGE,
             before: before,
             after: after
@@ -98,24 +100,23 @@ export const useModerationCommentsStore = defineStore('moderation-comments', {
           (edge: Edge<ModerationComment>) => edge.node
         )
 
-        if (newComments.length > 0) {
-          this.comments = newComments
-          this.totalCount = data.moderationComments.totalCount
-          this.startCursor = data.moderationComments.pageInfo.startCursor
-          this.endCursor = data.moderationComments.pageInfo.endCursor
+        this.comments = newComments
+        this.totalCount = data.moderationComments.totalCount
+        this.startCursor = data.moderationComments.pageInfo.startCursor
+        this.endCursor = data.moderationComments.pageInfo.endCursor
 
-          const forwardPaginating =
-            (before === null && after !== null) || (before === null && after === null)
-          const backwardPaginating = before !== null && after === null
+        const forwardPaginating =
+          (before === null && after !== null) || (before === null && after === null)
+        const backwardPaginating = before !== null && after === null
 
-          if (backwardPaginating) {
-            this.hasNextPage = true
-          }
-
-          if (forwardPaginating) {
-            this.hasNextPage = data.moderationComments.pageInfo.hasNextPage
-          }
+        if (backwardPaginating) {
+          this.hasNextPage = true
         }
+
+        if (forwardPaginating) {
+          this.hasNextPage = data.moderationComments.pageInfo.hasNextPage
+        }
+
         this.loading = false
       } catch (error) {
         console.error(error)

--- a/apps/ourvoice-app/src/stores/moderation-posts.ts
+++ b/apps/ourvoice-app/src/stores/moderation-posts.ts
@@ -96,6 +96,8 @@ export const useModerationPostsStore = defineStore('moderation-posts', {
           query: GET_MODERATION_POSTS_QUERY,
           variables: {
             status: status,
+            published: status === 'APPROVED' ? false : undefined,
+            archived: status === 'REJECTED' ? false : undefined,
             limit: MODERATION_LIST_POSTS_PER_PAGE,
             before: before,
             after: after


### PR DESCRIPTION
## Frontend Changes:
- Display only unpublished Approved posts/comments
- Display only unarchived Rejected posts/comments

## Backend Changes:
- Add `archivedAt`, `published`, `publishedAt` fields


